### PR TITLE
JsEvalResult should include js error stack

### DIFF
--- a/lib/javascriptcore/jscore_runtime.dart
+++ b/lib/javascriptcore/jscore_runtime.dart
@@ -79,7 +79,7 @@ class JavascriptCoreRuntime extends JavascriptRuntime {
     bool isPromise = false;
     if (exceptionValue.isObject) {
       result =
-          'ERROR: ${exceptionValue.toObject().getProperty("message").string}';
+          'ERROR: ${exceptionValue.toObject().getProperty("message").string} \n  at ${exceptionValue.toObject().getProperty("stack").string}';
     } else {
       result = _getJsValue(jsValueRef);
       JSValue resultValue = JSValuePointer(jsValueRef).getValue(context);


### PR DESCRIPTION
js error message should include [error.stack](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) to help debugging js codes