### PR TITLE
feat: added support to multiple params on console.log/warn/error

### DIFF
--- a/lib/javascript_runtime.dart
+++ b/lib/javascript_runtime.dart
@@ -107,7 +107,9 @@ abstract class JavascriptRuntime {
       }
     }""");
     onMessage('ConsoleLog', (dynamic args) {
-      print(args[1]);
+      args..removeAt(0);
+      String output = args.join(' ');
+      print(output);
     });
   }
 


### PR DESCRIPTION
Added support to console.log, warn and error print multiple parameters, not only in [1] position.
Fixes #40 

Example: 
`javascriptRuntime.evaluate("console.log(console.log(1,2,3,{a:1,b:2});)")`

Prints:
![image](https://user-images.githubusercontent.com/7197169/148773610-cd222914-4083-4337-9e1d-5487f6c26913.png)
