### PR TITLE
feat: manipulate ConsoleLog events on app's side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.5.0+5
 
-- Accept PR [67](https://github.com/abner/flutter_js/pull/67) to adjust channelFunction to return the function result when using JavascriptCore
+- Accept PR [67](https://github.com/abner/flutter_js/pull/67) to adjust channelFunction to return the function result when using JavascriptCore on Android
 
 # 0.5.0+4
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,7 +75,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0+4"
+    version: "0.5.0+5"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_js
 description: A Javascript engine to use with flutter. 
   It uses Quickjs on Android and JavascriptCore on IOS
-version: 0.5.0+4
+version: 0.5.0+5
 homepage: https://github.com/abner/flutter_js
 repository: https://github.com/abner/flutter_js
 


### PR DESCRIPTION
Hi!

I've added the possibility to handle ConsoleLog events on the app's side, not only on the library's side.

Imagine a scenario where I need to store console.log output on a variable for example, with the actual implementation I can't because the output of console.log events is only accessible on the library's side.

So this code:
![image (1)](https://user-images.githubusercontent.com/7197169/160010404-e73f61c6-c24b-4db4-b43a-cbfabc10423e.png)

Will have this output:
![image (2)](https://user-images.githubusercontent.com/7197169/160010434-e15b77b4-6bbe-4ffd-a746-c0c9602052c7.png)

Because this is how flutter_js is dealing with console events:
![image (3)](https://user-images.githubusercontent.com/7197169/160010484-464707a7-a5fd-4042-ae52-0a5d1625b6a5.png)


With my implementation (setting useFlutterTerminal to false) is now possible to choose if you want the console events to be handled by the library or app side

Like this:
![image (4)](https://user-images.githubusercontent.com/7197169/160010760-9095c882-8aa3-47a5-8c00-4d35e99a5632.png)

Giving this output:
![image (5)](https://user-images.githubusercontent.com/7197169/160010793-73fc7756-714c-4294-961c-3af73e07d0e7.png)


I am not so sure if `useFlutterTerminal` is the best name for it, I am accepting suggestions @abner 

Thanks!

