### PR TITLE
Replace jcenter with mavenCentral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.1
+
+- Remove deprecated jCenter android repository in favor of mavenCentral
+
 # 0.5.0+6
 
 - Accpted PR [66](https://github.com/abner/flutter_js/pull/66) to return the stack 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.4.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_js
 description: A Javascript engine to use with flutter. 
   It uses Quickjs on Android and JavascriptCore on IOS
-version: 0.5.0+6
+version: 0.5.1
 homepage: https://github.com/abner/flutter_js
 repository: https://github.com/abner/flutter_js
 


### PR DESCRIPTION
It has been the recommended transition for a while, my builds randomly fail because of jcenter. Do you want me to update the changelog+pubspec?