### PR TITLE
fix: #101 convert value return statically true

### DIFF
--- a/lib/quickjs/quickjs_runtime2.dart
+++ b/lib/quickjs/quickjs_runtime2.dart
@@ -207,7 +207,7 @@ class QuickJsRuntime2 extends JavascriptRuntime {
 
   @override
   T? convertValue<T>(JsEvalResult jsValue) {
-    return true as T;
+    return jsValue.rawResult as T;
   }
 
   @override


### PR DESCRIPTION
Tested on an android emulator. Seems to work as quickjs returns the actually value as rawResult and not a pointer like CoreJS