### PR TITLE
fix: #157 added required namespace attribute for latest AGP

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "io.abner.flutter_js"
     compileSdkVersion 29
 
     kotlinOptions {


### PR DESCRIPTION
I am a newbie in regards of flutter development.

So far it seems thats the only change that is required to compile it properly again on the latest AGP Versions