### PR TITLE
fix: remove android v1 embedding support

### DIFF
--- a/android/src/main/kotlin/io/abner/flutter_js/FlutterJsPlugin.kt
+++ b/android/src/main/kotlin/io/abner/flutter_js/FlutterJsPlugin.kt
@@ -9,7 +9,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import android.os.Looper
 import android.os.Handler
 // import fi.iki.elonen.NanoHTTPD
@@ -38,24 +37,7 @@ class FlutterJsPlugin : FlutterPlugin, MethodCallHandler {
         methodChannel!!.setMethodCallHandler(this)
     }
 
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-    // plugin registration via this function while apps migrate to use the new Android APIs
-    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-    //
-    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-    // in the same class.
     companion object {
-
-
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            val instance = FlutterJsPlugin()
-            instance.onAttachedToEngine(registrar.context(), registrar.messenger())
-        }
-
         var jsEngineMap = mutableMapOf<Int, JSEngine>()
     }
 

--- a/android/src/main/kotlin/io/abner/flutter_js/flutter_js/FlutterJsPlugin.kt
+++ b/android/src/main/kotlin/io/abner/flutter_js/flutter_js/FlutterJsPlugin.kt
@@ -7,7 +7,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 /** FlutterJsPlugin */
 class FlutterJsPlugin: FlutterPlugin, MethodCallHandler {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_js
 description: A Javascript engine to use with flutter.
   It uses Quickjs on Android and JavascriptCore on IOS
-version: 0.8.1
+version: 0.8.2
 homepage: https://github.com/abner/flutter_js
 repository: https://github.com/abner/flutter_js
 


### PR DESCRIPTION
Flutter 3.29.0 removed the previously deprectaed registrar (io.flutter.plugin.common.PluginRegistry.Registrar), this pr fixes building by removing support for it