### PR TITLE
Fix/reference leak

### DIFF
--- a/lib/quickjs/ffi.dart
+++ b/lib/quickjs/ffi.dart
@@ -255,9 +255,8 @@ void jsFreeRuntime(
   final referenceleak = <String>[];
   final opaque = runtimeOpaques[rt];
   if (opaque != null) {
-    while (true) {
-      final ref = opaque._ref.firstWhereOrNull((ref) => ref is JSRefLeakable);
-      if (ref == null) break;
+    while (opaque._ref.isNotEmpty) {
+      final ref = opaque._ref.first;
       ref.destroy();
       runtimeOpaques[rt]?._ref.remove(ref);
     }

--- a/test/flutter_js_test.dart
+++ b/test/flutter_js_test.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_js/extensions/fetch.dart';
+import 'package:flutter_js/extensions/xhr.dart';
 import 'package:flutter_js/flutter_js.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -7,7 +9,7 @@ void main() {
   late JavascriptRuntime jsRuntime;
 
   setUp(() {
-    jsRuntime = getJavascriptRuntime();
+    jsRuntime = getJavascriptRuntime(xhr: true);
   });
 
   tearDown(() {
@@ -23,5 +25,39 @@ void main() {
         '${result.rawResult.runtimeType}, ${result.stringResult.runtimeType}');
     expect(result.rawResult, equals(125));
     expect(result.stringResult, equals('125'));
+  });
+
+  test('leak test', () async {
+    final jsRt = getJavascriptRuntime();
+    jsRt.evaluate('''
+    delay = (delayInms) => {
+      return new Promise((resolve) => setTimeout(resolve, delayInms));
+    }
+    ''');
+    jsRt.evaluate('''
+    async function asyncTest(del = 30) {
+      try {
+        console.log(`Starting \$\{del\}...`);
+        while (del > 0) {
+          console.log(del);
+          await delay(1000);
+          del--;
+        }
+        console.log(`Done \$\{del\}`);
+        return `Done \$\{del\}`;
+      } catch (e) {
+        console.log(`Error in asyncTest: \$\{e\}`);
+        return "Error";
+      }
+    }
+    ''');
+    await jsRt.enableFetch();
+    jsRt.enableHandlePromises();
+    jsRt.enableXhr();
+    final promise = await jsRt.evaluateAsync('asyncTest(2)');
+    jsRt.executePendingJob();
+    JsEvalResult asyncResult = await jsRt.handlePromise(promise);
+    print('${asyncResult.stringResult}, ${asyncResult.stringResult}');
+    jsRt.dispose();
   });
 }


### PR DESCRIPTION
Found the root cause of reference leaks. There were still cases where reference leaks were happening depending on what kind of functions were being called in user javascript code. For example declaring arrow functions in js code would cause reference leaks on disposal. The disposal method was only freeing up "JSRefLeakable" instead of freeing everything. Added test case to test for these leaks.