### PR TITLE
fix - _parseJSException can return any type of exception

### DIFF
--- a/lib/quickjs/quickjs_runtime2.dart
+++ b/lib/quickjs/quickjs_runtime2.dart
@@ -195,7 +195,7 @@ class QuickJsRuntime2 extends JavascriptRuntime {
 
     if (jsIsException(jsval) != 0) {
       jsFreeValue(ctx, jsval);
-      JSError exception = _parseJSException(ctx);
+      final exception = _parseJSException(ctx);
       return JsEvalResult(exception.toString(), exception, isError: true);
     }
     final result = _jsToDart(ctx, jsval);


### PR DESCRIPTION
When _parseJSException returned any type other than JSError, the flutter_js package crashed. This is fixed by removing the explicit type.